### PR TITLE
Improve error handling on JSON parse failures on success messages

### DIFF
--- a/matrix-client/test/Spec.hs
+++ b/matrix-client/test/Spec.hs
@@ -7,6 +7,7 @@ module Main (main) where
 import Control.Monad (void)
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.ByteString.Lazy as BS
+import Data.Either (isLeft)
 import Data.Text (Text, pack)
 import Data.Time.Clock.System (SystemTime (..), getSystemTime)
 import Network.Matrix.Client
@@ -66,25 +67,25 @@ integration sess1 sess2 = do
 spec :: Spec
 spec = describe "unit tests" $ do
   it "decode unknown" $
-    (decodeResp "" :: Maybe (Either MatrixError String))
-      `shouldBe` Nothing
+    (decodeResp "" :: Either String (Either MatrixError String))
+      `shouldSatisfy` isLeft
   it "decode error" $
-    (decodeResp "{\"errcode\": \"TEST\", \"error\":\"a error\"}" :: Maybe (Either MatrixError String))
-      `shouldBe` (Just . Left $ MatrixError "TEST" "a error" Nothing)
+    (decodeResp "{\"errcode\": \"TEST\", \"error\":\"a error\"}" :: Either String (Either MatrixError String))
+      `shouldBe` (Right . Left $ MatrixError "TEST" "a error" Nothing)
   it "decode response" $
     decodeResp "{\"user_id\": \"@tristanc_:matrix.org\"}"
-      `shouldBe` (Just . Right $ UserID "@tristanc_:matrix.org")
+      `shouldBe` (Right . Right $ UserID "@tristanc_:matrix.org")
   it "decode reply" $ do
     resp <- decodeResp <$> BS.readFile "test/data/message-reply.json"
     case resp of
-      Just (Right (EventRoomReply eventID (RoomMessageText message))) -> do
+      Right (Right (EventRoomReply eventID (RoomMessageText message))) -> do
         eventID `shouldBe` EventID "$eventID"
         mtBody message `shouldBe` "> <@tristanc_:matrix.org> :hello\n\nHello there!"
       _ -> error $ show resp
   it "decode edit" $ do
     resp <- decodeResp <$> BS.readFile "test/data/message-edit.json"
     case resp of
-      Just (Right (EventRoomEdit (eventID, RoomMessageText srcMsg) (RoomMessageText message))) -> do
+      Right (Right (EventRoomEdit (eventID, RoomMessageText srcMsg) (RoomMessageText message))) -> do
         eventID `shouldBe` EventID "$eventID"
         mtBody srcMsg `shouldBe` " * > :typo"
         mtBody message `shouldBe` "> :hello"


### PR DESCRIPTION
Previously the library would report a network failure if the response
to an HTTP request couldn't be parsed either as a success value or an
error value. This commit improves the situation, by only reporting a
network failure if the HTTP response code is not successful and
reporting the JSON parse error (of the success value) otherwise.