### PR TITLE
Make SyncResultRoom's srrJoin optional

### DIFF
--- a/matrix-client/src/Network/Matrix/Client.hs
+++ b/matrix-client/src/Network/Matrix/Client.hs
@@ -464,7 +464,7 @@ data SyncResult = SyncResult
   deriving (Show, Eq, Generic)
 
 newtype SyncResultRoom = SyncResultRoom
-  { srrJoin :: Map Text JoinedRoomSync
+  { srrJoin :: Maybe (Map Text JoinedRoomSync)
   }
   deriving (Show, Eq, Generic)
 
@@ -607,7 +607,7 @@ getTimelines sr = foldrWithKey getEvents [] joinedRooms
     getEvents roomID jrs acc = case tsEvents (jrsTimeline jrs) of
       Just (x : xs) -> (RoomID roomID, x :| xs) : acc
       _ -> acc
-    joinedRooms = maybe mempty srrJoin (srRooms sr)
+    joinedRooms = fromMaybe mempty $ srRooms sr >>= srrJoin
 
 -------------------------------------------------------------------------------
 -- Derived JSON instances


### PR DESCRIPTION
The spec doesn't specify it as required and synapse apparently omits
it, if no events in joined rooms are returned.