### PR TITLE
Implement simple parsing of sync.rooms.invite

### DIFF
--- a/matrix-client/src/Network/Matrix/Client.hs
+++ b/matrix-client/src/Network/Matrix/Client.hs
@@ -72,6 +72,7 @@ module Network.Matrix.Client
     RoomEvent (..),
     RoomSummary (..),
     TimelineSync (..),
+    InvitedRoomSync (..),
     JoinedRoomSync (..),
     SyncResult (..),
     SyncResultRoom (..),
@@ -463,9 +464,13 @@ data SyncResult = SyncResult
   }
   deriving (Show, Eq, Generic)
 
-newtype SyncResultRoom = SyncResultRoom
+data SyncResultRoom = SyncResultRoom
   { srrJoin :: Maybe (Map Text JoinedRoomSync)
+  , srrInvite :: Maybe (Map Text InvitedRoomSync)
   }
+  deriving (Show, Eq, Generic)
+
+data InvitedRoomSync = InvitedRoomSync
   deriving (Show, Eq, Generic)
 
 unFilterID :: FilterID -> Text
@@ -643,6 +648,12 @@ instance ToJSON JoinedRoomSync where
 
 instance FromJSON JoinedRoomSync where
   parseJSON = genericParseJSON aesonOptions
+
+instance ToJSON InvitedRoomSync where
+  toJSON _ = object []
+
+instance FromJSON InvitedRoomSync where
+  parseJSON _ = pure InvitedRoomSync
 
 instance ToJSON SyncResult where
   toJSON = genericToJSON aesonOptions


### PR DESCRIPTION
This only allows obtaining the room IDs from invitations, because
InvitedRoomSync doesn't contain any information. For the moment a list
of Texts would be a cleaner solution, but in the future
more attributes will presumably be implemented for InvitedRoomSync, in
which case the current Map approach will make sense.