### PR TITLE
Even More Endpoints

### DIFF
--- a/matrix-client/matrix-client.cabal
+++ b/matrix-client/matrix-client.cabal
@@ -56,6 +56,7 @@ common lib-depends
                      , http-client            >= 0.5.0    && < 0.8
                      , http-client-tls        >= 0.2.0    && < 0.4
                      , http-types             >= 0.10.0   && < 0.13
+                     , network-uri
                      , profunctors
                      , retry                  ^>= 0.8
                      , text                   >= 0.11.1.0 && < 1.3

--- a/matrix-client/src/Network/Matrix/Client.hs
+++ b/matrix-client/src/Network/Matrix/Client.hs
@@ -39,6 +39,12 @@ module Network.Matrix.Client
 
     -- * Room Events
     EventType (..),
+    MRCreate (..),
+    MRCanonicalAlias (..),
+    MRGuestAccess (..),
+    MRHistoryVisibility (..),
+    MRName (..),
+    MRTopic (..),
     PaginatedRoomMessages (..),
     StateKey (..),
     StateEvent (..),

--- a/matrix-client/src/Network/Matrix/Client/Lens.hs
+++ b/matrix-client/src/Network/Matrix/Client/Lens.hs
@@ -18,6 +18,11 @@ module Network.Matrix.Client.Lens
   , _efNotTypes
   , _efSenders
   , _efTypes
+    -- PaginatedRoomMessages
+  , _chunk
+  , _end
+  , _start
+  , _state
     -- ResolvedRoomAlias
   , _roomAlias
   , _roomID
@@ -33,6 +38,24 @@ module Network.Matrix.Client.Lens
   , _refNotRooms
   , _refRooms
   , _refContainsUrl
+    -- StateContent
+  , _StateContentMRCreate
+  , _StateContentMRCanonicalAlias
+  , _StateContentMRGuestAccess
+  , _StateContentMRHistoryVisibility
+  , _StateContentMRName
+  , _StateContentMRTopic
+  , _StateContentMROther
+    -- StateEvent
+  , _seContent
+  , _seEventId
+  , _seOriginServerTimestamp
+  , _sePreviousContent
+  , _seRoomId
+  , _seSender
+  , _seStateKey
+  , _seEventType
+  , _seUnsigned
     -- StateFilter
   , _sfLimit
   , _sfNotSenders
@@ -189,6 +212,30 @@ _efTypes = lens getter setter
     getter = efTypes
     setter ef t = ef { efTypes = t }
 
+_chunk :: Lens' PaginatedRoomMessages [RoomEvent]
+_chunk = lens getter setter
+  where
+    getter = chunk
+    setter prm c = prm { chunk = c }
+
+_end :: Lens' PaginatedRoomMessages (Maybe T.Text)
+_end = lens getter setter
+  where
+    getter = end
+    setter prm e = prm { end = e }
+
+_start :: Lens' PaginatedRoomMessages T.Text
+_start = lens getter setter
+  where
+    getter = start
+    setter prm s = prm { start = s }
+
+_state :: Lens' PaginatedRoomMessages [StateEvent]
+_state = lens getter setter
+  where
+    getter = state
+    setter prm s = prm { state = s }
+
 _roomAlias :: Lens' ResolvedRoomAlias RoomAlias
 _roomAlias = lens getter setter
   where
@@ -266,6 +313,109 @@ _refContainsUrl = lens getter setter
   where
     getter = refContainsUrl
     setter ref rcu = ref { refContainsUrl = rcu }
+
+_StateContentMRCreate :: Prism' StateContent MRCreate
+_StateContentMRCreate = prism' to from
+  where
+    to = StRoomCreate
+    from (StRoomCreate create) = Just create
+    from _ = Nothing
+
+_StateContentMRCanonicalAlias :: Prism' StateContent MRCanonicalAlias
+_StateContentMRCanonicalAlias = prism' to from
+  where
+    to = StRoomCanonicalAlias
+    from (StRoomCanonicalAlias alias) = Just alias
+    from _ = Nothing
+
+_StateContentMRGuestAccess :: Prism' StateContent MRGuestAccess
+_StateContentMRGuestAccess = prism' to from
+  where
+    to = StRoomGuestAccess
+    from (StRoomGuestAccess guest) = Just guest
+    from _ = Nothing
+
+_StateContentMRHistoryVisibility :: Prism' StateContent MRHistoryVisibility
+_StateContentMRHistoryVisibility = prism' to from
+  where
+    to = StRoomHistoryVisibility
+    from (StRoomHistoryVisibility history) = Just history
+    from _ = Nothing
+
+_StateContentMRName :: Prism' StateContent MRName
+_StateContentMRName = prism' to from
+  where
+    to = StRoomName
+    from (StRoomName name) = Just name
+    from _ = Nothing
+
+_StateContentMRTopic :: Prism' StateContent MRTopic
+_StateContentMRTopic = prism' to from
+  where
+    to = StRoomTopic
+    from (StRoomTopic topic) = Just topic
+    from _ = Nothing
+
+_StateContentMROther :: Prism' StateContent J.Value
+_StateContentMROther = prism' to from
+  where
+    to = StOther
+    from (StOther other) = Just other
+    from _ = Nothing
+
+_seContent :: Lens' StateEvent StateContent
+_seContent = lens getter setter
+  where
+    getter = seContent
+    setter sec c = sec { seContent = c }
+
+_seEventId :: Lens' StateEvent EventID
+_seEventId = lens getter setter
+  where
+    getter = seEventId
+    setter sec eid = sec { seEventId = eid }
+
+_seOriginServerTimestamp :: Lens' StateEvent Integer
+_seOriginServerTimestamp = lens getter setter
+  where
+    getter = seOriginServerTimestamp
+    setter sec ts = sec { seOriginServerTimestamp = ts }
+
+_sePreviousContent :: Lens' StateEvent (Maybe J.Value)
+_sePreviousContent = lens getter setter
+  where
+    getter = sePreviousContent
+    setter sec c = sec { sePreviousContent = c }
+
+_seRoomId :: Lens' StateEvent RoomID
+_seRoomId = lens getter setter
+  where
+    getter = seRoomId
+    setter sec rid = sec { seRoomId = rid }
+
+_seSender :: Lens' StateEvent UserID
+_seSender = lens getter setter
+  where
+    getter = seSender
+    setter sec uid = sec { seSender = uid }
+
+_seStateKey :: Lens' StateEvent StateKey
+_seStateKey = lens getter setter
+  where
+    getter = seStateKey
+    setter sec key = sec { seStateKey = key }
+
+_seEventType :: Lens' StateEvent EventType
+_seEventType = lens getter setter
+  where
+    getter = seEventType
+    setter sec et = sec { seEventType = et }
+
+_seUnsigned :: Lens' StateEvent (Maybe J.Value)
+_seUnsigned = lens getter setter
+  where
+    getter = seUnsigned
+    setter sec val = sec { seUnsigned = val }
 
 _sfLimit :: Lens' StateFilter (Maybe Int)
 _sfLimit = lens getter setter

--- a/matrix-client/src/Network/Matrix/Internal.hs
+++ b/matrix-client/src/Network/Matrix/Internal.hs
@@ -14,7 +14,7 @@ import Control.Monad.Catch (Handler (Handler), MonadMask)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Retry (RetryStatus (..))
 import qualified Control.Retry as Retry
-import Data.Aeson (FromJSON (..), Value (Object), encode, eitherDecode, object, withObject, (.:), (.:?), (.=))
+import Data.Aeson (FromJSON (..), FromJSONKey (..), Value (Object), encode, eitherDecode, object, withObject, (.:), (.:?), (.=))
 import Data.ByteString.Lazy (ByteString, toStrict)
 import Data.Hashable (Hashable)
 import Data.Maybe (catMaybes, fromMaybe)
@@ -127,7 +127,8 @@ decodeResp resp = case eitherDecode resp of
     Right me -> Right $ Left me
     Left _ -> Left e
 
-newtype UserID = UserID Text deriving (Show, Eq, Ord, Hashable)
+newtype UserID = UserID Text
+  deriving (Show, Eq, Ord, Hashable, FromJSONKey)
 
 instance FromJSON UserID where
   parseJSON (Object v) = UserID <$> v .: "user_id"


### PR DESCRIPTION
Adds a few more endpoints:

- Getting
  -  [[https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomideventeventid][getRoomEvent]]
  - [[https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidjoined_members][getRoomMembers]]
  - [[https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidstate][getRoomState]]
  - [[https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey][getRoomStateEvent]]
  - [[https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidmessages][getRoomMessages]]
- Sending
  - [[https://spec.matrix.org/v1.1/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey][sendRoomStateEvent]]
  - [[https://spec.matrix.org/v1.1/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid][sendMessageEvent]]
  - [[https://spec.matrix.org/v1.1/client-server-api/#client-behaviour][redact]]


This branch is forked off my other current API branch. I figured it would be easier to review as a separate PR, but the other one should get merged first.