### PR TITLE
Updates Flake Lock and bumps GHC to 8.10.7

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(lorri direnv)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/dist-newstyle/

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1627838283,
-        "narHash": "sha256-YgxKXnyVltURwVPT+eIHPIgTaCb/1MrvebOmEHw2FBU=",
+        "lastModified": 1644101163,
+        "narHash": "sha256-TlTw09WeqGAvC+G+vkG6ee0efsLJpuiSp9F+Z1n/uGw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fc2cddf24ad1819f17174cbae47789294ea6dc4",
+        "rev": "ca410ca58d260fee74b12c5051f1ea9e19f6ef6c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         config = { };
-        compilerVersion = "8104";
+        compilerVersion = "8107";
         compiler = "ghc" + compilerVersion;
         overlays = [
           (final: prev: {
@@ -85,6 +85,7 @@
             doctest
             hlint
             pkgs.haskell-language-server
+            pkgs.ghcid
             testScript
             dendriteStart
             dendriteSetup

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+{ system ? builtins.currentSystem }:
+
+(builtins.getFlake (toString ./.)).devShell.${system}


### PR DESCRIPTION
The flake lock seemed a bit out of date so I updated it and bumped GHC to 8.10.7. I also added a `shell.nix` and `.envrc` so that we can use lorri and direnv with the flake. This also gets us HLS 1.5.1.0