### PR TITLE
Export room event Dir data type

### DIFF
--- a/matrix-client/CHANGELOG.md
+++ b/matrix-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.4.3
+
+- Add missing export for Dir.
+
 ## 0.1.4.2
 
 - Support retry-0.9

--- a/matrix-client/matrix-client.cabal
+++ b/matrix-client/matrix-client.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                matrix-client
-version:             0.1.4.2
+version:             0.1.4.3
 synopsis:            A matrix client library
 description:
     Matrix client is a library to interface with https://matrix.org.

--- a/matrix-client/src/Network/Matrix/Client.hs
+++ b/matrix-client/src/Network/Matrix/Client.hs
@@ -39,6 +39,7 @@ module Network.Matrix.Client
     getTokenOwner,
 
     -- * Room Events
+    Dir (..),
     EventType (..),
     MRCreate (..),
     MRCanonicalAlias (..),


### PR DESCRIPTION
This change exports a missing type that is required to use getRoomMessages.

Fixes #27 