### PR TITLE
Adds missing cabal version bounds.

### DIFF
--- a/matrix-client/matrix-client.cabal
+++ b/matrix-client/matrix-client.cabal
@@ -48,20 +48,20 @@ common common-options
 
 common lib-depends
   build-depends:       SHA                    ^>= 1.6
-                     , base64
-                     , bytestring
-                     , containers
-                     , exceptions
-                     , hashable
+                     , base64                 >= 0.4.2 && < 0.5
+                     , bytestring             >= 0.11.3 && < 0.12
+                     , containers             >= 0.6.5 && < 0.7
+                     , exceptions             >= 0.10.4 && < 0.11
+                     , hashable               >= 1.4.0 && < 1.5
                      , http-client            >= 0.5.0    && < 0.8
                      , http-client-tls        >= 0.2.0    && < 0.4
                      , http-types             >= 0.10.0   && < 0.13
-                     , network-uri
-                     , profunctors
+                     , network-uri            >= 2.6.4 && < 2.7
+                     , profunctors            >= 5.6.2 && < 5.7
                      , retry                  >= 0.8      && < 0.10
                      , text                   >= 0.11.1.0 && < 3
-                     , time
-                     , unordered-containers
+                     , time                   >= 1.11.1 && < 1.12
+                     , unordered-containers   >= 0.2.17 && < 0.3
 
 library
   import:              common-options, lib-depends


### PR DESCRIPTION
The missing cabal version bounds were causing the constraint solver to fail for me.