### PR TITLE
Further relax version bounds

### DIFF
--- a/matrix-client/matrix-client.cabal
+++ b/matrix-client/matrix-client.cabal
@@ -49,8 +49,8 @@ common common-options
 common lib-depends
   build-depends:       SHA                    ^>= 1.6
                      , base64                 >= 0.4.2 && < 0.5
-                     , containers             >= 0.6.5 && < 0.7
                      , bytestring             >= 0.11.3 && < 0.13
+                     , containers             >= 0.6.5 && < 0.8
                      , exceptions             >= 0.10.4 && < 0.11
                      , hashable               >= 1.4.0 && < 1.5
                      , http-client            >= 0.5.0    && < 0.8

--- a/matrix-client/matrix-client.cabal
+++ b/matrix-client/matrix-client.cabal
@@ -60,7 +60,7 @@ common lib-depends
                      , profunctors            >= 5.6.2 && < 5.7
                      , retry                  >= 0.8      && < 0.10
                      , text                   >= 0.11.1.0 && < 3
-                     , time                   >= 1.11.1 && < 1.12
+                     , time                   >= 1.11.1 && < 1.13
                      , unordered-containers   >= 0.2.17 && < 0.3
 
 library

--- a/matrix-client/matrix-client.cabal
+++ b/matrix-client/matrix-client.cabal
@@ -49,8 +49,8 @@ common common-options
 common lib-depends
   build-depends:       SHA                    ^>= 1.6
                      , base64                 >= 0.4.2 && < 0.5
-                     , bytestring             >= 0.11.3 && < 0.12
                      , containers             >= 0.6.5 && < 0.7
+                     , bytestring             >= 0.11.3 && < 0.13
                      , exceptions             >= 0.10.4 && < 0.11
                      , hashable               >= 1.4.0 && < 1.5
                      , http-client            >= 0.5.0    && < 0.8


### PR DESCRIPTION
In #38 I generated the missing version bounds using GHC 9.2.8. This resulted in overly restrictive upper bounds on a few packages. This PR relaxes the upper bounds on `containers`, `bytestring`, and `time` to allow for builds with newer versions of GHC.