### PR TITLE
Add support for reactions (`m.reaction` event)

### DIFF
--- a/src/Network/Matrix/Client.hs
+++ b/src/Network/Matrix/Client.hs
@@ -1228,6 +1228,7 @@ mkReply room re mt =
             EventRoomMessage (RoomMessageText oldMT) -> updateText oldMT
             EventRoomReply _ (RoomMessageText oldMT) -> updateText oldMT
             EventRoomEdit _ (RoomMessageText oldMT) -> updateText oldMT
+            EventReaction _ _ -> error $ "Can't reply to reaction"
             EventUnknown x -> error $ "Can't reply to " <> show x
      in EventRoomReply eventID (RoomMessageText newMessage)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -96,6 +96,13 @@ spec = describe "unit tests" $ do
                 mtBody srcMsg `shouldBe` " * > :typo"
                 mtBody message `shouldBe` "> :hello"
             _ -> error $ show resp
+    it "decode reaction" $ do
+        resp <- decodeResp <$> BS.readFile "test/data/reaction.json"
+        case resp of
+            Right (Right (EventReaction eventID (Annotation annText))) -> do
+                eventID `shouldBe` EventID "$eventID"
+                annText `shouldBe` "\128077"    -- :+1:
+            _ -> error $ show resp
     it "encode room message" $
         encodePretty (RoomMessageText (MessageText "Hello" TextType Nothing Nothing))
             `shouldBe` "{\"body\":\"Hello\",\"msgtype\":\"m.text\"}"

--- a/test/data/reaction.json
+++ b/test/data/reaction.json
@@ -1,0 +1,7 @@
+{
+  "m.relates_to": {
+    "event_id": "$eventID",
+    "key": "👍",
+    "rel_type": "m.annotation"
+  }
+}


### PR DESCRIPTION
This PR adds support for `m.reaction` events, as specified in https://spec.matrix.org/v1.17/client-server-api/#mreaction. This should close #29 once merged.

- Minor refactoring of related events parsing
- Decode test added
- References to the relevant sections of the Matrix specifications added